### PR TITLE
Fixing "accessing undeclared global" warning if "emote" mod is not installed

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -447,8 +447,7 @@ end
 function airutils.sit(player)
     --set_animation(frame_range, frame_speed, frame_blend, frame_loop)
     player:set_animation({x =  81, y = 160},30, 0, true)
-
-    if emote then emote.start(player:get_player_name(), "sit") end
+    if minetest.get_modpath("emote") then emote.start(player:get_player_name(), "sit") end
 end
 
 local function get_norm_angle(angle)


### PR DESCRIPTION
If the "emote" mod is not installed, Minetest throws a warning about accessing a undeclared global variable:
```
WARNING[Server]: Undeclared global variable "emote" accessed at /home/juri/Games/minetest/bin/../mods/airutils/init.lua:451
```
This small change doesn't try to access the global, it checks if the mod is available instead, which gets rid of the warning.