### PR TITLE
rewrite skinsdb support allowing to use it with 3d_armor

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -2,4 +2,4 @@ name = airutils
 title=AirUtils
 description=A lib for airplanes and some useful tools
 author=apercy
-optional_depends=player_api, emote, climate_api, biofuel, signs_lib
+optional_depends=player_api, emote, climate_api, biofuel, signs_lib, skinsdb


### PR DESCRIPTION
Challenge accepted in #17  ;-) Got time today to play lua.

The combination with 3d_armor looks fine. Armor is above the uniform.
Combination with 1.8er skins looks strange. The head is missing. Therefore I disabled uniform if 1.8er skins is used.