### PR TITLE
Fix `global_exists` usage

### DIFF
--- a/pilot_skin_manager.lua
+++ b/pilot_skin_manager.lua
@@ -97,11 +97,11 @@ function airutils.set_player_skin(player, skin)
         else
             --remove texture
             local old_texture = player_meta:get_string("backup")
-            if minetest.global_exists(set_skin) then --checking if set_skin is available 
+            if minetest.global_exists("set_skin") then --checking if set_skin is available
                 if player:get_attribute("set_skin:player_skin") ~= nil and player:get_attribute("set_skin:player_skin") ~= "" then
                     old_texture = player:get_attribute("set_skin:player_skin")
                 end
-            elseif minetest.global_exists(wardrobe) then --checking if wardrobe is available
+            elseif minetest.global_exists("wardrobe") then --checking if wardrobe is available
                 if wardrobe.playerSkins then
                     if wardrobe.playerSkins[name] ~= nil then
                         old_texture = wardrobe.playerSkins[name]


### PR DESCRIPTION
```
2024-12-27 10:35:02: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod 'airutils' in callback on_playerReceiveFields(): ../builtin/common/strict.lua:5: core.global_exists: nil is not a string
2024-12-27 10:35:02: ERROR[Main]: stack traceback:
2024-12-27 10:35:02: ERROR[Main]: 	[C]: in function 'error'
2024-12-27 10:35:02: ERROR[Main]: 	../builtin/common/strict.lua:5: in function 'global_exists'
2024-12-27 10:35:02: ERROR[Main]: 	.../worldmods/airutils/pilot_skin_manager.lua:100: in function 'set_player_skin'
2024-12-27 10:35:02: ERROR[Main]: 	.../worldmods/airutils/pilot_skin_manager.lua:151: in function <...g_tmp_3OIZX97O/worldmods/airutils/pilot_skin_manager.lua:147>
2024-12-27 10:35:02: ERROR[Main]: 	../builtin/common/register.lua:26: in function <.../builtin/common/register.lua:12>
```